### PR TITLE
Improve wording of ExoPlayer setting.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,5 +25,5 @@
     <string name="pref_music_notification_always_dismissible_title">Make music player notification always dismissible</string>
     <string name="pref_category_video_player">Native video player</string>
     <string name="pref_enable_exoplayer_title">Enable video player integration</string>
-    <string name="pref_enable_exoplayer_summary">Enable the experimental ExoPlayer video player which supports more video formats and codecs is more integrated into the OS</string>
+    <string name="pref_enable_exoplayer_summary">Enable the experimental ExoPlayer video player which supports more video formats and codecs, and is more integrated into the OS</string>
 </resources>


### PR DESCRIPTION
`Enable the experimental ExoPlayer video player which supports more video formats and codecs is more integrated into the OS`

The part `is more integrated into the OS` seems like it's talking about the codecs (`and codecs is more integrated...`) which I think was not the intention and is also not grammatically correct (`codecs is`). I have added `, and` to make it clear what is being said.